### PR TITLE
fix: fix GHA skip internally if no files changed to avoid stuck PR (#5)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -5,17 +5,46 @@ on:
     branches:
       - main
       - staging
-    paths:
-      - "**.md"
 
 jobs:
-  lint-markdown:
-    name: Check for Markdown Linting Errors
+  detect-changes:
+    name: Detect Changed Markdown
     runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.detect.outputs.should_skip }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Run markdownlint
+        with:
+          # Ensure we have the actual PR commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect .md Changes
+        id: detect
+        run: |
+          git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
+          CHANGED_FILES="$(git diff --name-only --diff-filter=AM HEAD origin/${{ github.base_ref }})"
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          if echo "$CHANGED_FILES" | grep -E '\.md$'; then
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  lint-markdown:
+    name: Check for Markdown Linting Errors
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run Markdownlint
         uses: articulate/actions-markdownlint@v1
         with:
           config: .markdownlint.jsonc

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -1,14 +1,10 @@
 name: Validate Markdown
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - staging
-
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
   detect-changes:

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -1,10 +1,14 @@
 name: Validate Markdown
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - staging
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   detect-changes:
@@ -13,17 +17,16 @@ jobs:
     outputs:
       should_skip: ${{ steps.detect.outputs.should_skip }}
     steps:
-      - name: Checkout Repo
+      - name: Checkout Base Repo (Safe Merge Commit)
         uses: actions/checkout@v4
         with:
-          # Ensure we have the actual PR commit
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Detect .md or .ipynb Changes
         id: detect
         run: |
           git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
-          CHANGED_FILES="$(git diff --name-only --diff-filter=AM HEAD origin/${{ github.base_ref }})"
+          CHANGED_FILES="$(git diff --name-only --diff-filter=AM origin/${{ github.base_ref }})"
 
           echo "Changed files:"
           echo "$CHANGED_FILES"
@@ -40,10 +43,10 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
-      - name: Checkout Repo
+      - name: Checkout Base Repo (Safe Merge Commit)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Check broken Paths
         id: check-broken-paths
         uses: john0isaac/action-check-markdown@v1.1.0
@@ -59,10 +62,10 @@ jobs:
     needs: [detect-changes, check-broken-paths]
     if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
-      - name: Checkout Repo
+      - name: Checkout Base Repo (Safe Merge Commit)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Run Check URLs Country Locale
         id: check-urls-locale
         uses: john0isaac/action-check-markdown@v1.1.0
@@ -78,10 +81,10 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
-      - name: Checkout Repo
+      - name: Checkout Base Repo (Safe Merge Commit)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Run Linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -1,23 +1,48 @@
 name: Validate Markdown
 
 on:
-  # Trigger the workflow on pull request
   pull_request_target:
     branches:
       - main
       - staging
-    paths:
-      - "**.md"
-      - "**.ipynb"
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  detect-changes:
+    name: Detect Changed Markdown/Notebook
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.detect.outputs.should_skip }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          # Ensure we have the actual PR commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect .md or .ipynb Changes
+        id: detect
+        run: |
+          git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
+          CHANGED_FILES="$(git diff --name-only --diff-filter=AM HEAD origin/${{ github.base_ref }})"
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          if echo "$CHANGED_FILES" | grep -E '\.md$|\.ipynb$'; then
+            echo "should_skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
   check-broken-paths:
     name: Check Broken Relative Paths
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -31,11 +56,12 @@ jobs:
           directory: ./
           guide-url: "https://github.com/0Upjh80d/agents/blob/main/CONTRIBUTING.md"
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
   check-urls-locale:
-    if: ${{ always() }}
-    needs: check-broken-paths
     name: Check URLs Don't Have Locale
     runs-on: ubuntu-latest
+    needs: [detect-changes, check-broken-paths]
+    if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -49,9 +75,12 @@ jobs:
           directory: ./
           guide-url: "https://github.com/0Upjh80d/agents/blob/main/CONTRIBUTING.md"
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
   check-broken-links:
     name: Check Broken Links
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -60,8 +89,8 @@ jobs:
       - name: Run Linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN  }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           fail_on_error: true
           config_file: .github/.linkspector.yml
-          filter_mode: nofilter # Runs check on all files instead of just changed files
+          filter_mode: nofilter

--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -17,16 +17,17 @@ jobs:
     outputs:
       should_skip: ${{ steps.detect.outputs.should_skip }}
     steps:
-      - name: Checkout Base Repo (Safe Merge Commit)
+      - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          # Ensure we have the actual PR commit
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Detect .md or .ipynb Changes
         id: detect
         run: |
           git fetch --no-tags --prune --depth=1 origin ${{ github.base_ref }}
-          CHANGED_FILES="$(git diff --name-only --diff-filter=AM origin/${{ github.base_ref }})"
+          CHANGED_FILES="$(git diff --name-only --diff-filter=AM HEAD origin/${{ github.base_ref }})"
 
           echo "Changed files:"
           echo "$CHANGED_FILES"
@@ -43,10 +44,10 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
-      - name: Checkout Base Repo (Safe Merge Commit)
+      - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check broken Paths
         id: check-broken-paths
         uses: john0isaac/action-check-markdown@v1.1.0
@@ -62,10 +63,10 @@ jobs:
     needs: [detect-changes, check-broken-paths]
     if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
-      - name: Checkout Base Repo (Safe Merge Commit)
+      - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run Check URLs Country Locale
         id: check-urls-locale
         uses: john0isaac/action-check-markdown@v1.1.0
@@ -81,10 +82,10 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}
     steps:
-      - name: Checkout Base Repo (Safe Merge Commit)
+      - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Run Linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:


### PR DESCRIPTION
# Pull Request

## Description

- Fixes #5 
  - Added `detect-changes` job 
  - Removed `paths`:  so the workflow always triggers.
  - Added condition inside the job — checks if any files ending in `.md` or `.ipynb` have changed.
  - Set an output `should_skip=true` if none of those files were modified.
  - Other jobs depend on `detect-changes`.
  - Each has `if: ${{ needs.detect-changes.outputs.should_skip == 'false' }}`.
  - This means they run only if `.md` or `.ipynb` files changed — otherwise they skip automatically, reporting success to GitHub.
  - This way, GitHub sees the job as completed/passed, and the PR can merge without needing an actual check run.
  - This ensures the workflow appears (so it won’t block merges if it’s a required check), yet the actual checks will exit successfully if none of those file types changed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please ensure the following have been completed:

- [x] I have read the `CONTRIBUTING.md` document.
- [x] The PR has a meaningful title.
- [x] I have summarized the changes of my PR.
- [x] The PR is ready to be merged and **NOT WORK IN PROGRESS**.
- [x] My code follows the code style of this project.

## Screenshots (if applicable)

NA.

## Additional Notes

NA.
