### PR TITLE
feat: frontend integration with dummy backend & display URLs in iFrame

### DIFF
--- a/app/backend/app/routers/dummy_orchestrator.py
+++ b/app/backend/app/routers/dummy_orchestrator.py
@@ -1,7 +1,17 @@
+import re
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 
 router = APIRouter(prefix="/dummy_orchestrator", tags=["dummy_orchestrator"])
+
+# Dummy global variables
+date_str = ""
+time_str = ""
+
+
+class OrchestratorRequest(BaseModel):
+    message: str
 
 
 class OrchestratorResponse(BaseModel):
@@ -11,22 +21,177 @@ class OrchestratorResponse(BaseModel):
     message: str
 
 
-@router.get("", response_model=OrchestratorResponse)
-async def dummy_orchestrator():
-    response = OrchestratorResponse(
+def parse_date_and_time(message: str):
+    global date_str, time_str
+    """
+    Parses date/time from a user message. Example inputs:
+      "28 mar, 10:00 am", "28 mar 10:00am", "10:00 pm 29 mar", "14:30 29 mar", etc.
+    Returns (date_str, time_str) or ("", "") if not found.
+      - date_str example: "28 March 2025"
+      - time_str example: "10:00 AM"
+    """
+
+    # Lowercase for matching
+    text = message.lower()
+
+    # Regex for e.g. "28 mar", "29 mar", "1 apr"
+    date_regex = r"\b(\d{1,2})\s*(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b"
+    # Regex for e.g. "10", "10:00", "10am", "10:00 pm", "14:30" etc.
+    time_regex = r"\b(\d{1,2})(?::(\d{1,2}))?\s*(am|pm)?\b"
+
+    date_match = re.search(date_regex, text)
+
+    # --- Parse date ---
+    month_map = {
+        "jan": "January",
+        "feb": "February",
+        "mar": "March",
+        "apr": "April",
+        "may": "May",
+        "jun": "June",
+        "jul": "July",
+        "aug": "August",
+        "sep": "September",
+        "oct": "October",
+        "nov": "November",
+        "dec": "December",
+    }
+
+    if date_match:
+        day = date_match.group(1)  # e.g. "28"
+        month_abbrev = date_match.group(2)  # e.g. "mar"
+        month_full = month_map.get(month_abbrev, month_abbrev.capitalize())
+        date_str = f"{day} {month_full} 2025"
+
+        # --- New: search for time after the date substring ---
+        time_search_text = text[date_match.end() :]
+    else:
+        time_search_text = text
+
+    time_match = re.search(time_regex, time_search_text)
+
+    # --- Parse time ---
+    if time_match:
+        hour_str = time_match.group(1)  # e.g. "10" or "14"
+        minute_str = time_match.group(2)  # e.g. "00" or None
+        ampm = time_match.group(3)  # e.g. "am", "pm", or None
+
+        hour = int(hour_str)
+        minute = int(minute_str) if minute_str else 0
+
+        # If user typed an explicit am/pm, use it. Otherwise, guess:
+        #   - 0 => 12 AM (midnight)
+        #   - 1..11 => AM
+        #   - 12..23 => PM
+        if not ampm:
+            if hour == 0:
+                ampm = "am"
+                hour_12 = 12
+            elif hour < 12:
+                ampm = "am"
+                hour_12 = hour
+            else:
+                ampm = "pm"
+                hour_12 = hour - 12 if hour > 12 else 12
+        else:
+            ampm = ampm.lower()
+            if hour > 12:
+                hour_12 = hour - 12
+            elif hour == 0:
+                hour_12 = 12
+            else:
+                hour_12 = hour
+
+        time_str = f"{hour_12}:{minute:02d} {ampm.upper()}"
+
+    return date_str, time_str
+
+
+@router.post("", response_model=OrchestratorResponse)
+async def orchestrate(request: OrchestratorRequest):
+    global date_str, time_str
+    user_message = request.message.lower().strip()
+
+    if "history" in user_message:
+        return OrchestratorResponse(
+            agent_name="Vaccine Record Agent",
+            data_type="vaccine_record",
+            data={"vaccines": ["Influenza (INF)", "Hepatitis B (HepB)"]},
+            message="Here is your vaccination history.",
+        )
+
+    elif any(word in user_message for word in ["change", "reschedule", "update"]):
+        # The user wants to change the date/time of an existing booking.
+        # Return the same booking slots or potentially different ones if you want
+        return OrchestratorResponse(
+            agent_name="Booking Agent",
+            data_type="booking_slots",
+            data={"slots": ["1 Apr, 9:00 AM", "2 Apr, 1:00 PM", "3 Apr, 4:00 PM"]},
+            message="Sure. Please choose a new date/time for your booking.",
+        )
+
+    elif "book" in user_message:
+        return OrchestratorResponse(
+            agent_name="Vaccine List Provider Agent",
+            data_type="vaccine_list",
+            data={
+                "vaccines": [
+                    "Influenza (INF)",
+                    "Pneumococcal Conjugate (PCV13)",
+                    "Human Papillomavirus (HPV)",
+                    "Tetanus, Diphtheria, Pertussis (Tdap)",
+                ]
+            },
+            message="Sure. Here are some recommended vaccines, please select one.",
+        )
+
+    elif user_message in [
+        "influenza (inf)",
+        "pneumococcal conjugate (pcv13)",
+        "human papillomavirus (hpv)",
+        "tetanus, diphtheria, pertussis (tdap)",
+    ]:
+        return OrchestratorResponse(
+            agent_name="Booking Agent",
+            data_type="booking_slots",
+            data={"slots": ["28 Mar, 10:00 AM", "29 Mar, 2:00 PM", "30 Mar, 11:00 AM"]},
+            message="Ok. Please select a booking slot from the following options.",
+        )
+
+    elif any(
+        keyword in user_message
+        for keyword in ["28 mar", "29 mar", "30 mar", "1 apr", "2 apr", "3 apr"]
+    ):
+        date_str, time_str = parse_date_and_time(user_message)
+        return OrchestratorResponse(
+            agent_name="Booking Agent",
+            data_type="booking_details",
+            data={
+                "clinic": "Sengkang Polyclinic",
+                "vaccine": "Influenza (INF)",
+                "date": date_str,
+                "time": time_str,
+            },
+            message="Please confirm these booking details.",
+        )
+
+    elif "confirm" in user_message:
+        return OrchestratorResponse(
+            agent_name="Booking Agent",
+            data_type="booking_success",
+            data={
+                "clinic": "Sengkang Polyclinic",
+                "vaccine": "Influenza (INF)",
+                "date": date_str,
+                "time": time_str,
+            },
+            message="Your booking has been confirmed! Please arrive 15 minutes earlier.",
+        )
+
+    # Fallback
+    return OrchestratorResponse(
         agent_name="Orchestrator Agent",
-        data_type="vaccine_record",
-        data={
-            "vaccines": [
-                "Influenza (INF)",
-                "Pneumococcal Conjugate (PCV13)",
-                "Human Papillomavirus (HPV)",
-                "Tetanus, Diphtheria, Pertussis (Tdap)",
-                "Hepatitis B (HepB)",
-                "Measles, Mumps, Rubella (MMR)",
-                "Varicella (VAR)",
-            ]
-        },
-        message="This is a dummy response from the orchestrator.",
+        data_type="general_query_response",
+        data={"link": "https://uat.hhtest.sg/"},
+        message="For more information, please visit our website.",
     )
-    return response

--- a/app/frontend/src/app/components/vaccine-index/vaccine-index.component.html
+++ b/app/frontend/src/app/components/vaccine-index/vaccine-index.component.html
@@ -1,4 +1,5 @@
 <div class="tw-flex tw-justify-center tw-items-center tw-h-[93vh]">
+  <!-- Left panel -->
   <div class="tw-w-1/2 tw-h-full tw-p-4 tw-flex tw-justify-center tw-items-center">
     <div class="tw-bg-white tw-shadow-md tw-rounded-lg tw-w-full tw-h-full tw-p-6 tw-flex tw-flex-col">
       <h1 class="tw-flex tw-justify-center tw-font-bold tw-text-2xl">Agentic Chatbot</h1>
@@ -29,19 +30,8 @@
                       'tw-items-start': true
                     }"
                     tabindex="-1"
-                  >
-                    <button
-                      *ngIf="!isVaccineSelected"
-                      [class]="
-                        'tw-overflow-auto tw-font-bold tw-px-3 tw-py-2 tw-rounded-2xl ' +
-                        (isLoggedIn ? 'content-card tw-cursor-default ' : 'tw-bg-red-500 tw-text-white')
-                      "
-                      (click)="isLoggedIn ? '' : SingpassLogin()"
-                    >
-                      {{ isLoggedIn ? (isBookVaccine ? "Please select one vaccine" : "Login successfully.") : "Log in with Singpass" }}
-                    </button>
-                  </div>
-                  <div *ngIf="isBookVaccine && isLoggedIn && !isVaccineSelected" class="tw-mt-4">
+                  ></div>
+                  <div *ngIf="isBookVaccine && !isVaccineSelected" class="tw-mt-4">
                     <div class="tw-overflow-x-auto tw-whitespace-nowrap">
                       <div class="tw-inline-flex tw-gap-2 tw-p-2 tw-rounded-lg">
                         @for (v of vaccines; track vaccines) {
@@ -52,8 +42,15 @@
                       </div>
                     </div>
                   </div>
+                  <!-- Booking Slots Section -->
+                  <div *ngIf="showBookingSlots" class="tw-my-4 tw-flex tw-gap-2 tw-flex-wrap tw-items-center">
+                    <!-- Display each slot as a button -->
+                    <button *ngFor="let slot of bookingSlots" (click)="handleUserInput(slot)" class="tw-bg-gray-100 tw-shadow-sm tw-rounded-lg tw-px-4 tw-py-2">
+                      {{ slot }}
+                    </button>
+                  </div>
                   <div *ngIf="isConfirming" class="tw-inline-flex tw-gap-2 tw-p-2 tw-rounded-lg">
-                    <button (click)="processUserInput('Confirm')" class="tw-bg-gray-100 tw-shadow-sm tw-rounded-lg tw-px-4 tw-py-2">Confirm</button>
+                    <button (click)="handleUserInput('Confirm')" class="tw-bg-gray-100 tw-shadow-sm tw-rounded-lg tw-px-4 tw-py-2">Confirm</button>
                   </div>
                 }
               }
@@ -66,6 +63,7 @@
       </div>
     </div>
   </div>
+  <!-- Right panel -->
   <div class="tw-w-1/2 tw-h-full tw-p-4 tw-flex tw-justify-center tw-items-center">
     <div class="tw-bg-white tw-shadow-md tw-rounded-lg tw-w-full tw-h-full tw-p-6 tw-flex tw-flex-col">
       <div class="tw-flex tw-items-center tw-justify-between">
@@ -73,9 +71,9 @@
         <div *ngIf="agentUsed !== ''" class="tw-inline-flex tw-gap-2 tw-p-2 tw-rounded-lg">
           <p class="tw-bg-gray-300 tw-shadow-sm tw-rounded-lg tw-px-4 tw-py-2">{{ agentUsed }}</p>
         </div>
-        <h1 [class]="'tw-flex-1 tw-font-bold tw-text-2xl tw-text-center ' + (agentUsed !== '' ? 'tw-mr-[100px]' : null)">Preview</h1>
+        <h1 [class]="'tw-flex-1 tw-font-bold tw-text-2xl tw-text-center ' + (agentUsed !== '' ? 'tw-mr-[100px]' : null)"></h1>
       </div>
-      <div *ngIf="isSinpassLogin" class="tw-flex tw-flex-col tw-h-full tw-overflow-hidden">
+      <div *ngIf="isSingpassLogin" class="tw-flex tw-flex-col tw-h-full tw-overflow-hidden">
         <!-- Header with logo -->
         <div class="tw-mb-6">
           <div class="tw-flex tw-items-center">
@@ -189,17 +187,13 @@
           </div>
         </div>
       </div>
-      <div *ngIf="isLoggedIn" class="tw-flex-1 tw-flex tw-flex-col tw-overflow-hidden">
+      <div class="tw-flex-1 tw-flex tw-flex-col tw-overflow-hidden">
         <div class="tw-p-6 tw-flex-shrink-0">
-          <h2 class="tw-text-3xl tw-font-bold tw-mb-2">Johnny</h2>
-          <div class="tw-mb-6">
-            <p class="tw-text-gray-700"><span class="tw-font-medium">Enrolled: </span> <b>Sengkang Polyclinic</b></p>
-            <p class="tw-text-gray-700"><span class="tw-font-medium">Address: </span> <b>544756</b></p>
-          </div>
+          <h2 class="tw-text-3xl tw-font-bold tw-mb-2">Hi Johnny</h2>
         </div>
-        <div class="tw-flex-1 tw-px-6">
+        <div class="tw-flex-1 tw-px-6 tw-mb-5">
           <!-- Current Vaccination Section -->
-          <div *ngIf="!isVaccineSelected || showConfirmed" class="tw-bg-gray-100 tw-rounded-lg tw-p-6 tw-mb-6">
+          <div *ngIf="showVaccinationRecords" class="tw-bg-gray-100 tw-rounded-lg tw-p-6 tw-mb-6">
             <h3 class="tw-text-xl tw-font-bold tw-mb-6">Current Vaccination</h3>
             <div [class]="'tw-overflow-y-auto ' + (showConfirmed ? 'tw-max-h-[130px]' : 'tw-max-h-[350px]')">
               @for (v of vaccinationRecords; track vaccinationRecords) {
@@ -212,20 +206,19 @@
               }
             </div>
           </div>
-
           <!-- Booking Details Section -->
-          <div *ngIf="isVaccineSelected || showConfirmed" class="tw-bg-gray-100 tw-rounded-lg tw-p-6 tw-mb-6">
+          <div *ngIf="showBookingDetails" class="tw-bg-gray-100 tw-rounded-lg tw-p-6 tw-mb-6">
             <h3 class="tw-text-xl tw-font-bold tw-mb-6">Booking Details</h3>
             <div [class]="'tw-overflow-y-auto ' + (showConfirmed ? 'tw-max-h-[130px]' : 'tw-max-h-[350px]')">
               <div *ngIf="!showConfirmed" class="tw-p-6">
                 <div class="tw-space-y-4">
                   <div class="tw-flex tw-items-start">
-                    <span class="tw-w-28 tw-font-medium">Clinic:</span>
-                    <span class="tw-font-bold">Sengkang Polyclinic</span>
-                  </div>
-                  <div class="tw-flex tw-items-start">
                     <span class="tw-w-28 tw-font-medium">Vaccine:</span>
                     <span class="tw-font-bold">{{ vaccineSelected }}</span>
+                  </div>
+                  <div class="tw-flex tw-items-start">
+                    <span class="tw-w-28 tw-font-medium">Clinic:</span>
+                    <span class="tw-font-bold">Sengkang Polyclinic</span>
                   </div>
                   <div class="tw-flex tw-items-start">
                     <span class="tw-w-28 tw-font-medium">Date:</span>
@@ -249,30 +242,6 @@
                     </span>
                   </div>
                 </div>
-                <div *ngIf="!hideSlotTable" class="tw-mt-6 tw-max-h-[200px] tw-overflow-y-auto">
-                  <table class="tw-w-full tw-border-collapse tw-border tw-border-gray-800">
-                    <thead>
-                      <tr>
-                        <th class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">Date</th>
-                        <th class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">Available Slots</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">28 Mar</td>
-                        <td class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">10</td>
-                      </tr>
-                      <tr>
-                        <td class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">29 Mar</td>
-                        <td class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">15</td>
-                      </tr>
-                      <tr>
-                        <td class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">30 Mar</td>
-                        <td class="tw-border tw-border-gray-800 tw-p-3 tw-text-center">20</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
               </div>
               <div *ngIf="showConfirmed" class="tw-border-b tw-border-gray-500 tw-pb-4 tw-mb-4 tw-max-w-md">
                 <div class="tw-flex tw-items-center tw-justify-between">
@@ -285,6 +254,10 @@
                 </div>
               </div>
             </div>
+          </div>
+          <!-- iframe for link preview -->
+          <div *ngIf="showLinkPreview" class="tw-h-full">
+            <iframe [src]="link" class="tw-w-full tw-h-full tw-border tw-rounded-lg" frameborder="0"></iframe>
           </div>
         </div>
       </div>

--- a/app/frontend/src/app/services/endpoint.service.ts
+++ b/app/frontend/src/app/services/endpoint.service.ts
@@ -43,10 +43,12 @@ export class EndpointService {
       );
   }
 
-  dummyOrchestrator(): Observable<any> {
-    return this.httpClient.get(`${this.baseUrl}/dummy_orchestrator`).pipe(
+  Orchestrator(userMessage: String): Observable<any> {
+    const body = { message: userMessage };
+
+    return this.httpClient.post(`${this.baseUrl}/dummy_orchestrator`, body).pipe(
       catchError(error => {
-        return throwError(() => new Error(error.error.detail));
+        return throwError(() => new Error(error.error?.detail ?? 'Error calling orchestrator'));
       })
     );
   }


### PR DESCRIPTION
# Pull Request

## Description
- Fixes #74, #75
- Overhaul frontend to use dummy backend endpoint instead of mocking on the frontend.
- Add change booking details flow for date/time only
- Add functionality to display responses to general user queries that include links. The link will be opened and displayed within the iframe on the right panel.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

Please ensure the following have been completed:

- [X] I have read the `CONTRIBUTING.md` document.
- [X] The PR has a meaningful title.
- [X] I have summarized the changes of my PR.
- [X] The PR is ready to be merged and **NOT WORK IN PROGRESS**.
- [X] My code follows the code style of this project.

## Screenshots (if applicable)
### Display of query and link url
![Screenshot 2025-04-08 at 2 55 14 PM](https://github.com/user-attachments/assets/b1bdb8d8-27ce-48b0-9fb7-90eee3c44817)


## Additional Notes
This is just a preliminary setup to reduce frontend reliance on frontend mockups. The proper workflow will still need to be established. 

